### PR TITLE
Add readme, license, and contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,92 @@
+# Contributing
+
+When contributing to this repository, please first discuss the change you wish to make via issue,
+email, or any other method with the owners of this repository before making a change.
+
+Please note we have a code of conduct, please follow it in all your interactions with the project.
+
+## Pull Request Process
+
+1. Ensure any install or build dependencies are removed before the end of the layer when doing a
+   build.
+2. Update the README.md with details of changes to the interface, this includes new environment
+   variables, exposed ports, useful file locations and container parameters.
+3. Increase the version numbers in any examples files and the README.md to the new version that this
+   Pull Request would represent. The versioning scheme we use is [SemVer](http://semver.org/).
+4. You may merge the Pull Request in once you have the sign-off of two other developers, or if you
+   do not have permission to do that, you may request the second reviewer to merge it for you.
+
+## Code of Conduct
+
+### Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+### Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+### Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+### Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+### Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+### Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ further defined and clarified by project maintainers.
 ### Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
+reported by contacting the project team at jon.mohrbacher@gmail.com. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,340 @@
+		    GNU GENERAL PUBLIC LICENSE
+		       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.
+                       59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+			    Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Library General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+		    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+			    NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+		     END OF TERMS AND CONDITIONS
+
+	    How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Library General
+Public License instead of this License.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is step by step series of examples that tell you how to get a development e
 
 We use [git](https://hackernoon.com/understanding-git-fcffd87c15a3) to track our file changes when developing. If you are new to git, consider downloading [github desktop](https://desktop.github.com/), and familiarize yourself with some git basics [here](https://hackernoon.com/understanding-git-fcffd87c15a3) and [here](https://hackernoon.com/understanding-git-2-81feb12b8b26). Once you're set up, clone this project to your machine.
 
-Install [mudlet](https://www.mudlet.org/download/). Open it up, and add a new profile with "tec.skotos.net" as the host and "6730" as the port. Do not enter a character name and password.
+Install [mudlet](https://www.mudlet.org/download/). Open it up, and add a new profile with `tec.skotos.net` as the host and `6730` as the port. Do not enter a character name and password.
 
 ![Screenshot from 2019-10-17 07-30-59](https://user-images.githubusercontent.com/3466499/67005268-38d67580-f0b0-11e9-9660-70ecffb995b7.png)
 
@@ -20,17 +20,17 @@ Click "Offline" rather than "Connect" to load the profile without connecting. Op
 
 ![Screenshot from 2019-10-31 18-10-17](https://user-images.githubusercontent.com/3466499/67989620-c619de00-fc09-11e9-849f-df91d68e8c6f.png)
 
-From this point on, you should be ready to tinker! Click "Connect" to connect to the game, and it will prompt you for your username and password. To edit the code, open one of the files you just installed, by clicking the "Scripts" button for example. Any changes you make here will be written back to your file system when you click "Save Profile". From here, you can use [git](https://hackernoon.com/understanding-git-2-81feb12b8b26) to contribute your changes to this repository.
+From this point on, you should be ready to tinker! Click "Connect" to connect to the game, and it will prompt you for your username and password. To edit some source code, open one of the files that you just installed -- for example, by clicking the "Scripts" button. Any changes you make here will be written back to your file system when you click "Save Profile". From here, you can use git to contribute your changes to this repository.
 
 ![Screenshot from 2019-10-31 18-20-21](https://user-images.githubusercontent.com/3466499/67990077-2b220380-fc0b-11e9-913d-79bee6ecc008.png)
 
 ## Running the tests
 
-Currently, we don't have a way to test our code, other than manually clicking through UI. The developers of mudlet itself have been considering adopting [a GUI testing framework](https://www.froglogic.com/squish/), and maybe we should consider it too.
+Currently, we don't have a way to test our code, other than manually clicking through UI. The developers of mudlet itself have been considering adopting a [GUI testing framework](https://www.froglogic.com/squish/), and maybe we should consider it too.
 
 ## Deployment
 
-We use [drone.io](https://drone.io), a cloud-based project automation service, to watch for activity on this github repository, and take action when it sees that we do certain things. Every time we cut [a release](https://github.com/TheEternalCitizens/mudlet-integration/releases), it uses [muddler](https://github.com/demonnic/muddler) to combine all the code in the `src` directory into an `mpackage` file, and then it uploads this file to the release page. This `mpackage` is how our users can install our code into their mudlet client.
+We use [drone.io](https://drone.io) -- a cloud-based project automation service -- to watch for activity on this github repository, and take action when it sees that we do certain things. Every time we cut [a release](https://github.com/TheEternalCitizens/mudlet-integration/releases), it uses [muddler](https://github.com/demonnic/muddler) to combine all the code in the `src` directory into an `mpackage` file, and then it uploads this file to the release page. This `mpackage` is how our users can install our code into their mudlet client.
 
 ## Built With
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,6 @@ This project is licensed under the GNU General Public License v2.0 License - see
 
 ## Acknowledgments
 
-* **Vadim Peretokin** [vadi2](https://github.com/vadi2) and the [many people that collaborate](https://github.com/Mudlet/Mudlet/contributors) with him in maintaining Mudlet
+* **Vadim Peretokin** - [vadi2](https://github.com/vadi2) and the [many people that collaborate](https://github.com/Mudlet/Mudlet/contributors) with him in maintaining Mudlet
 * **Damian Monogue** - [demonnic](https://github.com/demonnic) for muddler
 * **Billie Thompson** - [PurpleBooth](https://github.com/PurpleBooth) for this README's [template](https://gist.github.com/PurpleBooth/109311bb0361f32d87a2)

--- a/README.md
+++ b/README.md
@@ -1,65 +1,42 @@
-# Mudlet integration
+# TEC Mudlet Integration
 
-One Paragraph of project description goes here
+[Mudlet](https://www.mudlet.org/) is one of the most popular MUD clients, and so we decided to build an integration for it for our favorite MUD, [The Eternal City](https://www.skotos.net/games/eternal-city/). For more on mudlet, join [their discord server](https://discord.gg/kuYvMQ9). For more on The Eternal City, see [the unofficial wiki](http://eternal-city.wikidot.com/) and join [its discord server](https://discord.gg/fevBA8j).
 
 ## Getting Started
 
-These instructions will get you a copy of the project up and running on your local machine for development and testing purposes. See deployment for notes on how to deploy the project on a live system.
-
-### Prerequisites
-
-What things you need to install the software and how to install them
-
-```
-Give examples
-```
+These instructions will get you a copy of the project up and running on your local machine for development and testing purposes. See deployment for notes on how to deploy the project to users.
 
 ### Installing
 
-A step by step series of examples that tell you how to get a development env running
+This is step by step series of examples that tell you how to get a development environment running.
 
-Say what the step will be
+We use [git](https://hackernoon.com/understanding-git-fcffd87c15a3) to track our file changes when developing. If you are new to git, consider downloading [github desktop](https://desktop.github.com/), and familiarize yourself with some git basics [here](https://hackernoon.com/understanding-git-fcffd87c15a3) and [here](https://hackernoon.com/understanding-git-2-81feb12b8b26). Once you're set up, clone this project to your machine.
 
-```
-Give the example
-```
+Install [mudlet](https://www.mudlet.org/download/). Open it up, and add a new profile with "tec.skotos.net" as the host and "6730" as the port. Do not enter a character name and password.
 
-And repeat
+![Screenshot from 2019-10-17 07-30-59](https://user-images.githubusercontent.com/3466499/67005268-38d67580-f0b0-11e9-9660-70ecffb995b7.png)
 
-```
-until finished
-```
+Click "Offline" rather than "Connect" to load the profile without connecting. Open the "Module manager", which you can find in the "Toolbox" select menu in the toolbar at the top of the screen. "Install" all the `.xml` files in this project's `src/` directory, and set them to priority 1. Install `src/imgs.mpackage` as well, and set it to priority 0.
 
-End with an example of getting some data out of the system or using it for a little demo
+![Screenshot from 2019-10-31 18-10-17](https://user-images.githubusercontent.com/3466499/67989620-c619de00-fc09-11e9-849f-df91d68e8c6f.png)
+
+From this point on, you should be ready to tinker! Click "Connect" to connect to the game, and it will prompt you for your username and password. To edit the code, open one of the files you just installed, by clicking the "Scripts" button for example. Any changes you make here will be written back to your file system when you click "Save Profile". From here, you can use [git](https://hackernoon.com/understanding-git-2-81feb12b8b26) to contribute your changes to this repository.
+
+![Screenshot from 2019-10-31 18-20-21](https://user-images.githubusercontent.com/3466499/67990077-2b220380-fc0b-11e9-913d-79bee6ecc008.png)
 
 ## Running the tests
 
-Explain how to run the automated tests for this system
-
-### Break down into end to end tests
-
-Explain what these tests test and why
-
-```
-Give an example
-```
-
-### And coding style tests
-
-Explain what these tests test and why
-
-```
-Give an example
-```
+Currently, we don't have a way to test our code, other than manually clicking through UI. The developers of mudlet itself have been considering adopting [a GUI testing framework](https://www.froglogic.com/squish/), and maybe we should consider it too.
 
 ## Deployment
 
-Add additional notes about how to deploy this on a live system
+We use [drone.io](https://drone.io), a cloud-based project automation service, to watch for activity on this github repository, and take action when it sees that we do certain things. Every time we cut [a release](https://github.com/TheEternalCitizens/mudlet-integration/releases), it uses [muddler](https://github.com/demonnic/muddler) to combine all the code in the `src` directory into an `mpackage` file, and then it uploads this file to the release page. This `mpackage` is how our users can install our code into their mudlet client.
 
 ## Built With
 
-* [Mudlet](https://github.com/mudlet/mudlet) - The MUD client itself
-* [muddler](https://github.com/demonnic/muddler) - Used to turn our code into a mudlet package for distribution
+* [Mudlet](https://github.com/mudlet/mudlet) - The MUD client itself, and the editor we use when writing this code
+* [drone.io](https://drone.io) - The service that automates turning our code into a mudlet package
+* [muddler](https://github.com/demonnic/muddler) - The actual tool for turning our code into a mudlet package
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -83,8 +83,6 @@ This project is licensed under the GNU General Public License v2.0 License - see
 
 ## Acknowledgments
 
-* **Vadim Peretokin** [vadi2](https://github.com/vadi2) for Mudlet, [as well as all the other contributors](https://github.com/Mudlet/Mudlet/contributors)
+* **Vadim Peretokin** [vadi2](https://github.com/vadi2) and the [many people that collaborate](https://github.com/Mudlet/Mudlet/contributors) with him in maintaining Mudlet
 * **Damian Monogue** - [demonnic](https://github.com/demonnic) for muddler
 * **Billie Thompson** - [PurpleBooth](https://github.com/PurpleBooth) for this README's [template](https://gist.github.com/PurpleBooth/109311bb0361f32d87a2)
-* Inspiration
-* etc

--- a/README.md
+++ b/README.md
@@ -1,0 +1,90 @@
+# Mudlet integration
+
+One Paragraph of project description goes here
+
+## Getting Started
+
+These instructions will get you a copy of the project up and running on your local machine for development and testing purposes. See deployment for notes on how to deploy the project on a live system.
+
+### Prerequisites
+
+What things you need to install the software and how to install them
+
+```
+Give examples
+```
+
+### Installing
+
+A step by step series of examples that tell you how to get a development env running
+
+Say what the step will be
+
+```
+Give the example
+```
+
+And repeat
+
+```
+until finished
+```
+
+End with an example of getting some data out of the system or using it for a little demo
+
+## Running the tests
+
+Explain how to run the automated tests for this system
+
+### Break down into end to end tests
+
+Explain what these tests test and why
+
+```
+Give an example
+```
+
+### And coding style tests
+
+Explain what these tests test and why
+
+```
+Give an example
+```
+
+## Deployment
+
+Add additional notes about how to deploy this on a live system
+
+## Built With
+
+* [Mudlet](https://github.com/mudlet/mudlet) - The MUD client itself
+* [muddler](https://github.com/demonnic/muddler) - Used to turn our code into a mudlet package for distribution
+
+## Contributing
+
+Please read [CONTRIBUTING.md](https://github.com/TheEternalCitizens/mudlet-integration/blob/master/CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests to us.
+
+## Versioning
+
+We use [SemVer](http://semver.org/) for versioning. For the versions available, see the [tags on this repository](https://github.com/TheEternalCitizens/mudlet-integration/tags).
+
+## Authors
+
+* **David Gill** - *Initial work* - [davewiththenicehat](https://github.com/davewiththenicehat)
+* **Li-Hsuan Lung** - [naush](https://github.com/naush)
+* **Jonathan Mohrbacher** - [johnnymo87](https://github.com/johnnymo87)
+
+See also the list of [contributors](https://github.com/TheEternalCitizens/mudlet-integration/contributors) who participated in this project.
+
+## License
+
+This project is licensed under the GNU General Public License v2.0 License - see the [LICENSE.md](https://github.com/TheEternalCitizens/mudlet-integration/blob/master/LICENSE.md) file for details
+
+## Acknowledgments
+
+* **Vadim Peretokin** [vadi2](https://github.com/vadi2) for Mudlet, [as well as all the other contributors](https://github.com/Mudlet/Mudlet/contributors)
+* **Damian Monogue** - [demonnic](https://github.com/demonnic) for muddler
+* **Billie Thompson** - [PurpleBooth](https://github.com/PurpleBooth) for this README's [template](https://gist.github.com/PurpleBooth/109311bb0361f32d87a2)
+* Inspiration
+* etc


### PR DESCRIPTION
While I was working on https://github.com/TheEternalCitizens/mudlet-integration/pull/25, I thought it might be good to add a readme to this project. I went looking for a good template, and I found [this](https://gist.github.com/PurpleBooth/109311bb0361f32d87a2). It seems like a good start. I haven't finished filling everything out. For the license, I used [the same one mudlet uses](https://github.com/Mudlet/Mudlet/blob/development/COPYING).