### PR TITLE
Line up scroll bars, so that my eyes don't go 🤪

### DIFF
--- a/src/TEC Client Scripts.xml
+++ b/src/TEC Client Scripts.xml
@@ -1240,7 +1240,7 @@ GUIframe.defaults = {
     resizeWidth = 30,
     resizeHoverImage = "/imgs/blue_arrows.png",
     resizeRestImage = "/imgs/blue_arrows_30t.png",
-    borderOffset = 5,
+    borderOffset = 2,
 }
 
 GUIframe.windows = GUIframe.windows or {}


### PR DESCRIPTION
The scroll bar on the main window was further left than the scroll bar on the top one. I've found a way to line them up.

#### Before

![Screenshot from 2019-10-17 06-54-54](https://user-images.githubusercontent.com/3466499/67003017-1857ec80-f0ab-11e9-9ae5-8c164a4ab8fc.png)


#### After

![Screenshot from 2019-10-17 06-50-37](https://user-images.githubusercontent.com/3466499/67002913-db8bf580-f0aa-11e9-8352-1fd1ed7dce28.png)

By the way @davewiththenicehat, I think we should consider changing the border on the top window. Since there's no border on the main window, it leaves them feeling misaligned. If we change it from having a border on all sides to just having a border on the bottom, I think that might look better.