### PR TITLE
Skills Command Collection

### DIFF
--- a/src/TEC Client Aliases.xml
+++ b/src/TEC Client Aliases.xml
@@ -364,7 +364,7 @@ tecClientReset(true)</script>
 				<packageName></packageName>
 				<regex>^parthia tab font size (.*)$</regex>
 			</Alias>
-			<Alias isActive="no" isFolder="no">
+			<Alias isActive="yes" isFolder="no">
 				<name>parthia update</name>
 				<script>DownloadGitScripts() --Begin downloading updates</script>
 				<command></command>
@@ -1381,6 +1381,13 @@ lookRan = true --tell triggers player has run the look command</script>
 				<command></command>
 				<packageName></packageName>
 				<regex>^(?i)(?:l(?:ook|oo|o)?)\s*$</regex>
+			</Alias>
+			<Alias isActive="yes" isFolder="no">
+				<name>skills</name>
+				<script>runSkillsCollection(true) --collect data from stats command showing command to screen</script>
+				<command></command>
+				<packageName></packageName>
+				<regex>^(?i)(?:skill(?:s)?)\s*$</regex>
 			</Alias>
 		</AliasGroup>
 		<AliasGroup isActive="yes" isFolder="yes">

--- a/src/TEC Client KeyBindings.xml
+++ b/src/TEC Client KeyBindings.xml
@@ -16,7 +16,7 @@ runTECRoomObjectCheck()</script>
 			<keyCode>82</keyCode>
 			<keyModifier>67108864</keyModifier>
 		</Key>
-		<KeyGroup isActive="yes" isFolder="yes">
+		<KeyGroup isActive="no" isFolder="yes">
 			<name>numpad navigation</name>
 			<packageName></packageName>
 			<script></script>

--- a/src/TEC Client Scripts.xml
+++ b/src/TEC Client Scripts.xml
@@ -372,6 +372,8 @@ function tecClientReset(displayToScreen) --reset all client settings to defaults
   statsFilter = {}
   --used to filter data from the condition command 
   conditionFilter = {}
+  --table to store variables to filter data from the skills command
+  skillsFilter = {}
   
   --Stores player related data
   parthiaPlayer = {}
@@ -9023,6 +9025,52 @@ end --function runStatsCollection()</script>
 					</Script>
 				</ScriptGroup>
 				<ScriptGroup isActive="yes" isFolder="yes">
+					<name>skills</name>
+					<packageName></packageName>
+					<script>--[[
+collect data from the skills command
+]]--</script>
+					<eventHandlerList />
+					<Script isActive="yes" isFolder="no">
+						<name>getSkillsCheckActive()</name>
+						<packageName></packageName>
+						<script>function getSkillsCheckActive()
+  return skillsFilter.checkActive
+end --function getSkillsCheckState()</script>
+						<eventHandlerList />
+					</Script>
+					<Script isActive="yes" isFolder="no">
+						<name>setSkillsCheckActive(mode)</name>
+						<packageName></packageName>
+						<script>function setSkillsCheckActive(mode)
+  mode = fuzzyBoolean(mode)
+  skillsFilter.checkActive = mode --a stats check is active
+  if skillsFilter.checkActive then --if disabeling
+    enableTrigger("skills") --enable trigger for skills collection
+    skillsFilter.hrFound = false --needed for finding the end of the skills command
+    debugToDisplay("function setSkillsCheckActive, enabled skills check")
+    tempTimer(2, [[setSkillsCheckActive(false)]]) --disable this data collection after 2 seconds incase it does not disable in the trigger
+  else
+    disableTrigger("skills") --disable the trigger for skills collections
+    debugToDisplay("function setSkillsCheckActive, disabled skills check")
+    skillsFilter.displayToScreen = true --if the check is done make certain displayToScreen is true
+  end --if not mode
+end --function setStatsCheckActive(mode)</script>
+						<eventHandlerList />
+					</Script>
+					<Script isActive="yes" isFolder="no">
+						<name>runSkillsCollection(displayToScreen)</name>
+						<packageName></packageName>
+						<script>function runSkillsCollection(displayToScreen)
+  displayToScreen = fuzzyBoolean(displayToScreen) 
+  setSkillsCheckActive(true) --tell Parthia we will be collecting stats data
+  send("skills",displayToScreen) --send command, do not echo
+  skillsFilter.displayToScreen = displayToScreen --tell stats filter not to display command to pecho
+end --function runStatsCollection()</script>
+						<eventHandlerList />
+					</Script>
+				</ScriptGroup>
+				<ScriptGroup isActive="yes" isFolder="yes">
 					<name>condition</name>
 					<packageName></packageName>
 					<script>-------------------------------------------------
@@ -9563,7 +9611,8 @@ parthiaMap = parthiaMap or {} --table to hold the mapper data.
 --parthiaMap.entryIndex = 1 --index used to tell what exit was entered through to get to current room
 --parthiaMap.exitIndex = 1 --index used to tell what exit was exited through from previous room to get to current room
 --parthiaMap.descriptionOfExitUsed = "" --stores the description of the exit player used.
---parthiaMap.moveNeeded = false --Movement needs to be delayed because sometimes there is not SKOOT 10 message. This is used to track if movement has already begun. Used in function parthiaMap.delayMove()</script>
+--parthiaMap.moveNeeded = false --Movement needs to be delayed because sometimes there is not SKOOT 10 message. This is used to track if movement has already begun. Used in function parthiaMap.delayMove()
+--parthiaMap.danger = 0 --Used to show a message to player if they lack </script>
 				<eventHandlerList />
 				<Script isActive="yes" isFolder="no">
 					<name>parthiaMap.resetRoom()</name>

--- a/src/TEC Client Triggers.xml
+++ b/src/TEC Client Triggers.xml
@@ -835,6 +835,54 @@ end</script>
 					<integer>4</integer>
 				</regexCodePropertyList>
 			</Trigger>
+			<Trigger isActive="no" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+				<name>skills</name>
+				<script>--[[
+to collect data when the character runs the commands we will want aliases for all the ways
+the skills command can be run. Including short hand versions
+Those aliases will set skillsCheckActive.
+A seporate bool will controll if the command is still shown to screen. skillsFilter.displayToScreen
+Collect data into a table. parthiaPlayer.CurrentCharacter.name
+References
+https://www.lua.org/pil/20.2.html string patterns
+https://wiki.mudlet.org/w/Manual:String_Functions
+]]--
+
+--Remove these to items if they are found.
+if line:match("Total Combat Ranks:") then --find combat rank line
+  parthiaPlayer.CurrentCharacter.combatRanks = line:match("Total Combat Ranks:%s+(%d+)") --collect combat ranks
+  if not skillsFilter.displayToScreen then deleteLine() end --if not displaying to screen, remove line from main
+elseif line:match("Total Non%-Combat Ranks:") then --find combat rank line
+  parthiaPlayer.CurrentCharacter.noncombatRanks = line:match("Total Non%-Combat Ranks:%s+(%d+)") --collect combat ranks
+  if not skillsFilter.displayToScreen then deleteLine() end --if not displaying to screen, remove line from main
+elseif line == "&lt;hr&gt;" then
+  if skillsFilter.hrFound then --this command begins and ends with an &lt;hr&gt; if we found the second one. Disable the filter.
+    setSkillsCheckActive(false) --disable skills check collection
+  end --if skillsFilter.hrFound
+  if not skillsFilter.displayToScreen then --if we do not want to display images to screen
+    deleteLine() --remove so it will not be displayed
+    disableTrigger("&lt;hr&gt;") --disable seporator trigger so it is not drawn
+  end --if not skillsFilter.displayToScreen
+else --for all other lines remove them from screen if they 
+  if not skillsFilter.displayToScreen then deleteLine() end --if not displaying to screen, remove line from main
+end --if line:match("^Total Combat Ranks:") elseif</script>
+				<triggerType>0</triggerType>
+				<conditonLineDelta>0</conditonLineDelta>
+				<mStayOpen>0</mStayOpen>
+				<mCommand></mCommand>
+				<packageName></packageName>
+				<mFgColor>#ff0000</mFgColor>
+				<mBgColor>#ffff00</mBgColor>
+				<mSoundFile></mSoundFile>
+				<colorTriggerFgColor>#000000</colorTriggerFgColor>
+				<colorTriggerBgColor>#000000</colorTriggerBgColor>
+				<regexCodeList>
+					<string>return getSkillsCheckActive()</string>
+				</regexCodeList>
+				<regexCodePropertyList>
+					<integer>4</integer>
+				</regexCodePropertyList>
+			</Trigger>
 			<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
 				<name>condition</name>
 				<script>--[[
@@ -1074,9 +1122,11 @@ if tecUsername then tecUsername = nil end --remove the username, it is no longer
 tecResetRoomCharacterWindow()
 
 --collect player data, 1 second wait due to one command per second limitation
---runConditionCollection(false)
+tempTimer(.6,[[pecho("Please wait while parthia collects information about this character.")]]) --wait until after the notification message is displayed.
 parthiaPlayer.CurrentCharacter = { }
 local statsCollectionTimer = tempTimer(1.1, [[runStatsCollection(false)]])
+tempTimer(2.5, [[runSkillsCollection(false)]])
+tempTimer(3, [[pecho("Completed character information collection.\n")]])
 
 parthiaStopScripts() --stop all automation scripts</script>
 				<triggerType>0</triggerType>


### PR DESCRIPTION
Added ability to collect combat and non-combat ranks from the skills command.

Aliases.xml
1385 - 1391, Created alaise to collect skills command.

Scripts.xml
375 - 376, Table for skills filter
9023 - 9036, created function getSkillsCheckActive. Gets the state of skill command collection
9040-9060, created function setSkillsCheckActive, sets the state of skills command collection
9061 - 9068, created function runSkillsCollection, to start the collection of data from skills command.

triggers.xml
838 - 885, created trigger `skills`. It collects the number of combat and non combat skill ranks the current character has.
1125-1129, trigger `Successful login` runs command skills and filters it off the screen. This runs after the automatic run of the stats command. As a result, just after the notification message. A message informing the player to wait while parthia collects data about the current character is displayed. Than a message when all the commands are done is displayed also.