### PR TITLE
Automations Bugfix Winter 2022

### DIFF
--- a/src/TEC Client Aliases.xml
+++ b/src/TEC Client Aliases.xml
@@ -1266,7 +1266,7 @@ groupName, parthiaAutomationGroupPosition, command, repeatOnFail, insert, trigge
 parthiaAutomationUpdate("automation", groupName, parthiaAutomationGroupPosition, command, trigger, repeatOnFail, insert)</script>
 					<command></command>
 					<packageName></packageName>
-					<regex>^parthia\s+automation\s+([a-zA-Z0-9\s+]+),\s+(\d+)\s+=\s+([a-zA-Z0-9\s+]+),\s+(\d+),\s+(\d+)\s+&amp;\s+(.+)$</regex>
+					<regex>^parthia\s+automation\s+([a-zA-Z0-9\s+]+),\s+(\d+)\s+=\s+([a-zA-Z0-9\|\s+]+),\s+(\d+),\s+(\d+)\s+&amp;\s+(.+)$</regex>
 				</Alias>
 				<Alias isActive="yes" isFolder="no">
 					<name>parthia interrupt [group name], [position number] = [command], [repeat on fail], [insert] &amp; [trigger]</name>
@@ -1284,7 +1284,7 @@ groupName, parthiaAutomationGroupPosition, command, repeatOnFail, insert, trigge
 parthiaAutomationUpdate("automationInterrupt", groupName, parthiaAutomationGroupPosition, command, trigger, repeatOnFail, insert)</script>
 					<command></command>
 					<packageName></packageName>
-					<regex>^parthia\s+interrupt\s+([a-zA-Z0-9\s+]+),\s+(\d+)\s+=\s+([a-zA-Z0-9\s+]+),\s+(\d+),\s+(\d+)\s+&amp;\s+(.+)$</regex>
+					<regex>^parthia\s+interrupt\s+([a-zA-Z0-9\s+]+),\s+(\d+)\s+=\s+([a-zA-Z0-9\|\s+]+),\s+(\d+),\s+(\d+)\s+&amp;\s+(.+)$</regex>
 				</Alias>
 				<Alias isActive="yes" isFolder="no">
 					<name>parthia interrupt [group name], [repeat], [call pattern]~ [first command trigger]</name>

--- a/src/TEC Client Aliases.xml
+++ b/src/TEC Client Aliases.xml
@@ -2030,6 +2030,13 @@ parthiaStopScripts(true) --stop all automation scripts, display message to scree
 			<packageName></packageName>
 			<regex>^(?i)stop\s*$</regex>
 		</Alias>
+		<Alias isActive="yes" isFolder="no">
+			<name>All Commands</name>
+			<script>-- This triggers on any command.</script>
+			<command></command>
+			<packageName></packageName>
+			<regex></regex>
+		</Alias>
 	</AliasPackage>
 	<ActionPackage />
 	<ScriptPackage />

--- a/src/TEC Client KeyBindings.xml
+++ b/src/TEC Client KeyBindings.xml
@@ -19,7 +19,7 @@ tecRefreshSettingsWindow()</script>
 			<keyCode>82</keyCode>
 			<keyModifier>67108864</keyModifier>
 		</Key>
-		<KeyGroup isActive="yes" isFolder="yes">
+		<KeyGroup isActive="no" isFolder="yes">
 			<name>numpad navigation</name>
 			<packageName></packageName>
 			<script></script>

--- a/src/TEC Client KeyBindings.xml
+++ b/src/TEC Client KeyBindings.xml
@@ -19,7 +19,7 @@ tecRefreshSettingsWindow()</script>
 			<keyCode>82</keyCode>
 			<keyModifier>67108864</keyModifier>
 		</Key>
-		<KeyGroup isActive="no" isFolder="yes">
+		<KeyGroup isActive="yes" isFolder="yes">
 			<name>numpad navigation</name>
 			<packageName></packageName>
 			<script></script>

--- a/src/TEC Client Scripts.xml
+++ b/src/TEC Client Scripts.xml
@@ -17,9 +17,12 @@ Winter 2022 - 2023
   
   Minor bugfix: players running very old accounts that do not have the colored text patterns sent out for all standard room messages could not use the run courses command. This has been fixed.
   
+  Bugfix: parthia automation and interrupt creation commands would not accept | in the input. Preventing the player from creating 'or' logic in their automations.
+  
   Improvement: Made the choice to have the stop command stop all automation types that are currently running.
   
-  Improvement: When clicking the create an interrupt or create an automation command the messages have been made consideraly shorted. So people may actually read them now.
+  Improvement: Dramatically shortened the help message that appears when a player clicks the 'create an automatio' and 'create an interrupt' windows.
+      Previous to this there was too much text, so it was not being read.
   
 Not completed yet:
 
@@ -8363,7 +8366,7 @@ function GitUpdateconfig() --Create variables used for updates
     debugToDisplay("Update: ERROR localRespitory was not present. Has been created.")
   end --if GitUpdate.localRespitory not exist
   GitUpdate.gitReleaseURLJSONFile = "ParthiaLatest.json" --local file name REST API latest JSON
-  GitUpdate.localVersion = "0.1.54" --Must match the tag in your github release
+  GitUpdate.localVersion = "0.1.55" --Must match the tag in your github release
   GitUpdate.aliasName = "parthia update" --Name of alias user runs to process update
   --Name of the alias to check if an update is available.
   GitUpdate.updateCheckAlias = "parthia update check" 

--- a/src/TEC Client Scripts.xml
+++ b/src/TEC Client Scripts.xml
@@ -10206,6 +10206,7 @@ function parthiaAutomationStop(displayToScreen)
   parthiaAutomationFirstRun = true
   parthiaLastCommandSuccess = false
   parthiaAutomationRepeatCmdOnFailure = false
+  parthiaAutomationPaused = false
   
   -- Stop any running interrupts
   parthiaAutomationInterruptStop()
@@ -12226,7 +12227,7 @@ function parthiaStopScripts(displayToScreen)
   if parthiaGetWaitForDrover() then parthiaSetWaitForDrover(false, displayToScreen) end --if running, disable waiting for drover script
   
   -- stop automation scripts
-  if parthiaAutomationRunning then
+  if parthiaAutomationRunning or parthiaAutomationPaused or parthiaAutomationInterruptRunning then
     parthiaAutomationStop(displayToScreen)
   end -- if parthiaAutomationRunning then
 

--- a/src/TEC Client Scripts.xml
+++ b/src/TEC Client Scripts.xml
@@ -527,6 +527,8 @@ function tecClientReset(displayToScreen) --reset all client settings to defaults
   interruptDataFolder = getMudletHomeDir().."\/Interrupt Data\/"
   
   unfilteredTextConsoleMode = false  -- a snap out console window ( userWindow ) that shows unfiltered text from TEC
+  
+  parthiaCollect = {}  -- Used to hold data functions other misc for the collection system.
 
   if displayToScreen then pecho("Parthia settings set to default.\n") end
 
@@ -11461,9 +11463,9 @@ Commands to assist with data collection.
 
 Useage:
   `parthia collect NAME = REGEXSTRING`: To do a standard data collection.
-  `parthia collecttime NAME = REGEXSTRING`: Collects line with the REGEXSTRING in it.
-    With `=#` at the end. Where the number is the number of seconds it took for `You are no longer busy`
-    to appear after the string was found.
+  `parthia collecttime NAME = REGEXSTRING~0 OR REGEXSTRING`: Collects line with the first REGEXSTRING in it.
+    With `=#` at the end. Where the number is the number of seconds it took for the second regexstring to appear
+    The ~0, means it will time until the `You are no longer busy.` message appears, rather than the second regex string
   `parthia collect NAME = export`: to export to a directory on the computer.
   `parthia collect open export`: to open the export directory.
     
@@ -11474,10 +11476,29 @@ Desired functions:
     The line must collect to a table that matches the same of the collection.
   Have ability to collect the time. Than time when 'You are no longer busy.' appears.
   Has to export to a file.
+  Has to have a clickable interface like parthia automation
     
 
 ]]--</script>
 					<eventHandlerList />
+					<Script isActive="yes" isFolder="no">
+						<name>parthiaCollect.CreateCollection()</name>
+						<packageName></packageName>
+						<script>--[[
+
+  Creates the data store for a collection.
+
+]]--
+
+function parthiaCollect.CreateCollection(name, timed)
+
+  --name, is the name of the collection
+  --timed, is if the collection should record how long before a second message appears
+
+
+end  -- function parthiaCollect.CreateCollection</script>
+						<eventHandlerList />
+					</Script>
 				</ScriptGroup>
 			</ScriptGroup>
 			<ScriptGroup isActive="yes" isFolder="yes">

--- a/src/TEC Client Scripts.xml
+++ b/src/TEC Client Scripts.xml
@@ -11478,11 +11478,21 @@ Desired functions:
   Has to export to a file.
   Has to have a clickable interface like parthia automation
     
+    
+Outline
+  parthiaCollect, table to save all the collection functions and data.
+  parthiaCollect.collections, table to save all the data being collected
+    parthiaCollect.collections[parthiaPlayer.CurrentCharacter.name], a table to store collections for a username
+      collections[name].collectPattern, the regex pattern that when found informs mudlet to collect the line.
+      collections[name].endPattern, false if no timer, 0 if timer end is `no longer busy`
+        a string for a regex pattern end
+  parthiaColllect.UpdateCollection, function to create or update collections on a player.
+    
 
 ]]--</script>
 					<eventHandlerList />
 					<Script isActive="yes" isFolder="no">
-						<name>parthiaCollect.CreateCollection()</name>
+						<name>parthiaCollect.UpdateCollection()</name>
 						<packageName></packageName>
 						<script>--[[
 
@@ -11490,13 +11500,19 @@ Desired functions:
 
 ]]--
 
-function parthiaCollect.CreateCollection(name, timed)
+function parthiaCollect.UpdateCollection(name, collectPattern, endPattern)
 
-  --name, is the name of the collection
-  --timed, is if the collection should record how long before a second message appears
+  --name, is the name of the collection.
+  --collectPattern, the regex pattern that determins the line to collect.
+  --endPattern, when to end timing collection.
+  
+  -- If endPattern is 0 or a string, this is a timed collection and a timer will need to be created.
+  local timed
 
+  --if the collection does not already exist. Create it now.
+  
 
-end  -- function parthiaCollect.CreateCollection</script>
+end  -- function parthiaCollect.UpdateCollection</script>
 						<eventHandlerList />
 					</Script>
 				</ScriptGroup>

--- a/src/TEC Client Scripts.xml
+++ b/src/TEC Client Scripts.xml
@@ -7367,7 +7367,7 @@ Handles refreshing the text in the interrupts window.
     
     cechoLink("automationWindowConsole",
       "&lt;:"..tecSettings.helpHighlightColor.."&gt;create an automation\n\n", 
-      [[parthiaAutomationUpdateHelp()]],
+      [[parthiaAutomationUpdateHelpBrief()]],
       "parthia automation groups", true)
       
     cechoLink("automationWindowConsole",
@@ -9749,7 +9749,7 @@ function parthiaAutomationUpdateHelp(automationType)
   
   pecho("For a tutorial video on making an Automation Group go to ")
   pechoLink("&lt;:"..tecSettings.helpHighlightColor.."&gt;https://youtu.be/rCHHD866J3I\n\n", 
-    [[openUrl("https://www.youtube.com/watch?v=rCHHD866J3I&amp;list=PLKL4xCxZxZqL7G_i4v0pdPL4Sdn36nhps&amp;index=2")]], 
+    [[parthiaAutomationUpdateHelp("automation")]], 
     "youtube parthia automation tutorial", true)
   
   pecho("Command Format:\n")
@@ -9781,7 +9781,31 @@ function parthiaAutomationTriggerHelp()
     [[openUrl("https://www.youtube.com/watch?v=JVsgRNT6YLo&amp;list=PLKL4xCxZxZqL7G_i4v0pdPL4Sdn36nhps&amp;index=4")]], 
     "youtube parthia automation tutorial", true)
   
-end -- function parthiaAutomationTriggerHelp()</script>
+end -- function parthiaAutomationTriggerHelp()
+
+
+function parthiaAutomationUpdateHelpBrief()
+
+  automationType = automationType or "automation"
+  -- parthia automation [group name], [position number] = [command], [seconds or 0], [repeat on fail]
+  
+  pecho("\n\nAutomation creation tutorial options:\n\n")
+
+  pecho("\tFor a text tutorial on making an Automation Group click or enter ")
+  pechoLink("&lt;:"..tecSettings.helpHighlightColor.."&gt;parthia automation update\n\n", 
+    [[parthiaAutomationUpdateHelp("automation")]], 
+    "text tutorial on creating an automation", true)
+  
+  pecho("For a tutorial video on making an Automation Group go to ")
+  pechoLink("&lt;:"..tecSettings.helpHighlightColor.."&gt;https://youtu.be/rCHHD866J3I\n\n", 
+    [[openUrl("https://www.youtube.com/watch?v=rCHHD866J3I&amp;list=PLKL4xCxZxZqL7G_i4v0pdPL4Sdn36nhps&amp;index=2")]], 
+    "youtube parthia automation tutorial", true)
+  
+  pecho("Command Format:\n")
+  pecho("parthia "..automationType.." [group name], [position number] = [command], [repeat on fail], [insert] &amp; [trigger]\n")
+  printCmdLine("parthia "..automationType.." replace_with_your_group, 1 = replace_with_your_command, 0, 0 &amp; 0")
+
+end -- function parthiaAutomationUpdateHelp()</script>
 						<eventHandlerList />
 					</Script>
 					<Script isActive="yes" isFolder="no">
@@ -9913,7 +9937,7 @@ function parthiaInterruptCreateHelpBrief()
 
   pecho("\nInterrupt Creation tutorial options:\n\n")
 
-  pecho("\n\tFor a text tutorial click or enter ")
+  pecho("\tFor a text tutorial click or enter ")
   pechoLink("&lt;:"..tecSettings.helpHighlightColor.."&gt;parthia interrupt create\n\n", 
     [[parthiaInterruptCreateHelp()]], 
     "interrupt creation text tutorial", true)

--- a/src/TEC Client Scripts.xml
+++ b/src/TEC Client Scripts.xml
@@ -10093,19 +10093,22 @@ function parthiaAutomationCall()
   if parthiaToBoolean(groupRepeat) then  -- Only check if a group repeat was specified.
     if iterationCounter &gt;= tonumber(groupRepeat) then  -- this has iterated more than group repeat specified
       if automationType == "automationInterrupt" then
-        
         pecho("\nInterrupt "..groupName.." completed.\n")
-        
         -- Stop the interrupt system
         local continueAutomation = parthiaAutomationInterruptStop()
-        
-        -- 
+        -- There is no need to continue automation so stop now
         if not continueAutomation then
-        
           return true
-        
         end  -- if not continueAutomation
-        
+        -- Since automation needs to continue after this. Gather data from the running automation
+        -- Get required variables for this function.  
+        groupName = parthiaAutomationRunning["groupName"]  -- the name of this automation group
+        groupRepeat = parthiaAutomationRunning["groupRepeat"]  -- How many times this group automation should repeat
+        automationType = "automation"  -- This is a standard automation task.
+        -- setting this now, incase the previous task should repeat.
+        groupPosition = parthiaAutomationGroupPosition
+        -- How many times this automation group has repeated
+        iterationCounter = parthiaAutomationIterationCounter
       -- This is a standard automation task.
       else
         pecho("\nAutomation task "..groupName.." complete.\n")
@@ -12009,6 +12012,12 @@ end --function sortCombatActions(stringToCheck)</script>
 end --function sortNonCombatActions</script>
 						<eventHandlerList />
 					</Script>
+				</ScriptGroup>
+				<ScriptGroup isActive="yes" isFolder="yes">
+					<name>CustomCollection</name>
+					<packageName></packageName>
+					<script></script>
+					<eventHandlerList />
 				</ScriptGroup>
 			</ScriptGroup>
 			<ScriptGroup isActive="yes" isFolder="yes">

--- a/src/TEC Client Scripts.xml
+++ b/src/TEC Client Scripts.xml
@@ -9414,22 +9414,6 @@ How automation interupts are handled-------------------------------------------
       Check if the interrupt is currently active
         if yes turn it off with parthiaAutomationInterruptToggleState
       parthiaAutomationShowGroups() is called with the group name and deletion switch. Deleting the group
-      
-  Intterupt call again if character was busy logic:
-    Variable parthiaInterruptCommandSuccess is false if the `you are busy` messages appear.
-	    This variable informs parthia that it needs to run the interrupt again.
-    Triggers\Game Evenets\You will be busy for
-      If an interrupt is running and the interrupt command is set to repeat on command failure
-        Sets parthiaInterruptCommandSuccess to false. To note that the interrupt command did not run.
-    Triggers\Game Evenets\You are in the middle of something.
-      If an interrupt is running and the interrupt command is set to repeat on command failure
-        Sets parthiaInterruptCommandSuccess to false. To note that the interrupt command did not run.
-    scripts\automation\parthiaAutomationInterruptStop
-      Sets parthiaInterruptCommandSuccess to true, the system assumes the command was a success.
-    scripts\automation\parthiaAutomationInterruptStart
-      Sets parthiaInterruptCommandSuccess to true, the system assumes the command was a success.
-    script\automation\parthiaAutomationCall
-      Sets parthiaInterruptCommandSuccess to true, the system assumes the command was a success.
   
   Aliases
     create an interupt group.
@@ -10122,12 +10106,7 @@ function parthiaAutomationCall()
   
   -- Update the iteration counter
   if parthiaAutomationInterruptRunning then
-    --Increase iterator if the interrupt command was a success.
-    if parthiaInterruptCommandSuccess then
-      iterationCounter = parthiaAutomationInterruptIterationCounter
-    end -- parthiaInterruptCommandSuccess
-    -- set parthiaInterruptCommandSuccess to default state of true
-    parthiaInterruptCommandSuccess = true
+    iterationCounter = parthiaAutomationInterruptIterationCounter
   else  -- this is a standard automation task collect from that table instead.
     iterationCounter = parthiaAutomationIterationCounter
   end -- if parthiaAutomationInterruptRunning then

--- a/src/TEC Client Scripts.xml
+++ b/src/TEC Client Scripts.xml
@@ -7274,7 +7274,7 @@ Handles refreshing the text in the interrupts window.
     
     cechoLink("interruptsWindowConsole",
       "&lt;:"..tecSettings.helpHighlightColor.."&gt;create an interrupt\n\n", 
-      [[parthiaInterruptCreateHelp()]],
+      [[parthiaInterruptCreateHelpBrief()]],
       "parthia automation groups", true)
       
     cechoLink("interruptsWindowConsole",
@@ -9906,7 +9906,28 @@ function parthiaInterruptCreateHelp()
   pecho("parthia interrupt [group name], [repeat], [call pattern]~ [first command trigger]\n")
   printCmdLine("parthia interrupt replace_with_your_group, 1, trigger_when_text_is_received~ 0")
   
-end  -- function parthiaInterruptCreateHelp()</script>
+end  -- function parthiaInterruptCreateHelp()
+
+
+function parthiaInterruptCreateHelpBrief()
+
+  pecho("\nInterrupt Creation tutorial options:\n\n")
+
+  pecho("\n\tFor a text tutorial click or enter ")
+  pechoLink("&lt;:"..tecSettings.helpHighlightColor.."&gt;parthia interrupt create\n\n", 
+    [[parthiaInterruptCreateHelp()]], 
+    "interrupt creation text tutorial", true)
+  
+  pecho("\n\tFor a tutorial video on making an Interrupt and Interrupt Automation Group go to ")
+  pechoLink("&lt;:"..tecSettings.helpHighlightColor.."&gt;https://youtu.be/8n9vycwod1U\n\n", 
+    [[openUrl("https://youtu.be/8n9vycwod1U")]], 
+    "youtube parthia automation tutorial", true)
+  
+  pecho("Command Format:\n\n")
+  pecho("\tparthia interrupt [group name], [repeat], [call pattern]~ [first command trigger]\n")
+  printCmdLine("parthia interrupt replace_with_your_group, 1, trigger_when_text_is_received~ 0")
+  
+end  -- parthiaInterruptCreateHelpbrief()</script>
 						<eventHandlerList />
 					</Script>
 					<Script isActive="yes" isFolder="no">

--- a/src/TEC Client Scripts.xml
+++ b/src/TEC Client Scripts.xml
@@ -9412,6 +9412,22 @@ How automation interupts are handled-------------------------------------------
       Check if the interrupt is currently active
         if yes turn it off with parthiaAutomationInterruptToggleState
       parthiaAutomationShowGroups() is called with the group name and deletion switch. Deleting the group
+      
+  Intterupt call again if character was busy logic:
+    Variable parthiaInterruptCommandSuccess is false if the `you are busy` messages appear.
+	    This variable informs parthia that it needs to run the interrupt again.
+    Triggers\Game Evenets\You will be busy for
+      If an interrupt is running and the interrupt command is set to repeat on command failure
+        Sets parthiaInterruptCommandSuccess to false. To note that the interrupt command did not run.
+    Triggers\Game Evenets\You are in the middle of something.
+      If an interrupt is running and the interrupt command is set to repeat on command failure
+        Sets parthiaInterruptCommandSuccess to false. To note that the interrupt command did not run.
+    scripts\automation\parthiaAutomationInterruptStop
+      Sets parthiaInterruptCommandSuccess to true, the system assumes the command was a success.
+    scripts\automation\parthiaAutomationInterruptStart
+      Sets parthiaInterruptCommandSuccess to true, the system assumes the command was a success.
+    script\automation\parthiaAutomationCall
+      Sets parthiaInterruptCommandSuccess to true, the system assumes the command was a success.
   
   Aliases
     create an interupt group.
@@ -9515,10 +9531,6 @@ Track command success----------------------------------------------------------
   Triggers\Game Events\player involved in an action
     Triggers when player is involved in an action
     calls Scripts\Actions\sortActions()
-  Triggers\Game Evenets\You will be busy for
-    Sets parthiaLastCommandSuccess to false. To not that the command did not run.
-  Triggers\Game Evenets\You are in the middle of something.
-    Sets parthiaLastCommandSuccess to false. To not that the command did not run.
   Scripts\Actions\sortActions() 
       Determins if the action is combat or non combat than calls
       If it is a combat action: Scripts\Actions\sortCombatActions() is called
@@ -10063,7 +10075,12 @@ function parthiaAutomationCall()
   
   -- Update the iteration counter
   if parthiaAutomationInterruptRunning then
-    iterationCounter = parthiaAutomationInterruptIterationCounter
+    --Increase iterator if the interrupt command was a success.
+    if parthiaInterruptCommandSuccess then
+      iterationCounter = parthiaAutomationInterruptIterationCounter
+    end -- parthiaInterruptCommandSuccess
+    -- set parthiaInterruptCommandSuccess to default state of true
+    parthiaInterruptCommandSuccess = true
   else  -- this is a standard automation task collect from that table instead.
     iterationCounter = parthiaAutomationIterationCounter
   end -- if parthiaAutomationInterruptRunning then
@@ -10781,6 +10798,9 @@ function parthiaAutomationInterruptStop()
     --  Set the automation variables back to running state.
     parthiaAutomationRunning = parthiaAutomationPaused
     parthiaAutomationPaused = false
+    
+    -- set arthiaInterruptCommandSuccess to default state of true
+    arthiaInterruptCommandSuccess = true
   
     debugToDisplay("parthiaAutomationInterruptStop completed succesfully, automation resume return true sent.")
     
@@ -10815,6 +10835,9 @@ function parthiaAutomationInterruptStart(groupName)
   
   --Setting automation first run to true, so we can iterate through the automation group properly
   parthiaAutomationFirstRun = true
+  
+  -- Set arthiaInterruptCommandSuccess to default state of true
+  arthiaInterruptCommandSuccess = true
   
   -- Setting the interrupt running variable, to keep track of this interrupt
   parthiaAutomationInterruptRunning = groupName

--- a/src/TEC Client Scripts.xml
+++ b/src/TEC Client Scripts.xml
@@ -7,6 +7,32 @@
 	<ActionPackage />
 	<ScriptPackage>
 		<Script isActive="yes" isFolder="no">
+			<name>ReleaseNotes</name>
+			<packageName></packageName>
+			<script>--[[
+
+Winter 2022 - 2023
+
+  Minor bugfix: characters completing an interrupt would not automatically resume their last running automation.
+  
+  Minor bugfix: players running very old accounts that do not have the colored text patterns sent out for all standard room messages could not use the run courses command. This has been fixed.
+  
+  Improvement: Made the choice to have the stop command stop all automation types that are currently running.
+  
+  Improvement: When clicking the create an interrupt or create an automation command the messages have been made consideraly shorted. So people may actually read them now.
+  
+Not completed yet:
+
+  Major improvement: In hunting grounds that have a single entry and exit point. Add the ability for Parthia Maps to automatically move to the top of its tab. It displays the current hunting ground you are on. Though with an image that looks like an over the top view of the hunting ground. As you move it tracks movement as standard mudlet mapping feature does. Intended for beginer hunting grounds for now. Could add features like fog of war later.
+
+  Improvement: Add automations and interrupts to their data folders. Allowing for prepackaged automations that people can import directly on installation.
+
+  Major improvement: add the ability to collect game data via regex triggers. For example when an attack is dodged, you could record each attack of the desired type ( when it was dodged ) and review what dodge dodged it. You could record stat improvements. Gleams. Really endless options. Just restricted to regex triggers. For text should fit anyones needs.
+
+]]--</script>
+			<eventHandlerList />
+		</Script>
+		<Script isActive="yes" isFolder="no">
 			<name>fuzzyBoolean(bool)</name>
 			<packageName></packageName>
 			<script>-- Provided by demonnic

--- a/src/TEC Client Scripts.xml
+++ b/src/TEC Client Scripts.xml
@@ -9398,7 +9398,9 @@ How automation interupts are handled-------------------------------------------
           Than calls the first command in the interrupt group.
           
   Interrupt stop logic:
-    parthiaAutomationCall
+    parthiaInterruptStop, called flags interrupt variables accordingly.
+      If automation was running previous to the interrupt parthiaInterruptStop flags automation variables to resume.
+      If automation should be resumed after the interrupt is stopped parthiaInterruptStop returns True
   
   Interrupt Disable Logic:
     parthiaAutomationInterruptToggleState is called.
@@ -10070,13 +10072,25 @@ function parthiaAutomationCall()
   if parthiaToBoolean(groupRepeat) then  -- Only check if a group repeat was specified.
     if iterationCounter &gt;= tonumber(groupRepeat) then  -- this has iterated more than group repeat specified
       if automationType == "automationInterrupt" then
+        
         pecho("\nInterrupt "..groupName.." completed.\n")
-        parthiaAutomationInterruptStop()
+        
+        -- Stop the interrupt system
+        local continueAutomation = parthiaAutomationInterruptStop()
+        
+        -- 
+        if not continueAutomation then
+        
+          return true
+        
+        end  -- if not continueAutomation
+        
+      -- This is a standard automation task.
       else
         pecho("\nAutomation task "..groupName.." complete.\n")
-        parthiaAutomationStop()  -- Stop automation.
+        parthiaAutomationStop()  -- Stop automation loop.
+        return true  -- stop current automation call also.
       end -- if automationType == "automationInterrupt" then
-      return true  -- stop current automation call also.
     end  -- if parthiaAutomationIterationCounter &gt; tonumber(groupRepeat) then
   end -- if parthiaToBoolean(groupRepeat) then
   
@@ -10746,6 +10760,9 @@ end  -- function parthiaCreateAutomationRegexTrigger(pattern)</script>
 						<packageName></packageName>
 						<script>--[[
 Stop the currently running interrupt automation task.
+
+Returns:
+  True if automation should resume after the interrupt is stopped.
 ]]--
 
 function parthiaAutomationInterruptStop()
@@ -10756,13 +10773,21 @@ function parthiaAutomationInterruptStop()
   
   -- if an automation task was paused, unpause it now.
   if parthiaAutomationPaused then
+    
+    --  Set the automation variables back to running state.
     parthiaAutomationRunning = parthiaAutomationPaused
     parthiaAutomationPaused = false
+  
+    debugToDisplay("parthiaAutomationInterruptStop completed succesfully, automation resume return true sent.")
+    
+    -- Return true, showing that standard automation should be called.
+    return true
+    
   end --if parthiaAutomationPaused then
   
   debugToDisplay("parthiaAutomationInterruptStop completed succesfully.")
   
-  return true
+  return false
   
 end -- function parthiaAutomationInterruptStop()</script>
 						<eventHandlerList />

--- a/src/TEC Client Scripts.xml
+++ b/src/TEC Client Scripts.xml
@@ -9515,6 +9515,10 @@ Track command success----------------------------------------------------------
   Triggers\Game Events\player involved in an action
     Triggers when player is involved in an action
     calls Scripts\Actions\sortActions()
+  Triggers\Game Evenets\You will be busy for
+    Sets parthiaLastCommandSuccess to false. To not that the command did not run.
+  Triggers\Game Evenets\You are in the middle of something.
+    Sets parthiaLastCommandSuccess to false. To not that the command did not run.
   Scripts\Actions\sortActions() 
       Determins if the action is combat or non combat than calls
       If it is a combat action: Scripts\Actions\sortCombatActions() is called

--- a/src/TEC Client Scripts.xml
+++ b/src/TEC Client Scripts.xml
@@ -11452,6 +11452,33 @@ end  -- function parthiaAutomationCleanRegExTriggers()</script>
 						<eventHandlerList />
 					</Script>
 				</ScriptGroup>
+				<ScriptGroup isActive="yes" isFolder="yes">
+					<name>collect</name>
+					<packageName></packageName>
+					<script>--[[
+
+Commands to assist with data collection.
+
+Useage:
+  `parthia collect NAME = REGEXSTRING`: To do a standard data collection.
+  `parthia collecttime NAME = REGEXSTRING`: Collects line with the REGEXSTRING in it.
+    With `=#` at the end. Where the number is the number of seconds it took for `You are no longer busy`
+    to appear after the string was found.
+  `parthia collect NAME = export`: to export to a directory on the computer.
+  `parthia collect open export`: to open the export directory.
+    
+    
+
+Desired functions:
+  Collect an entire line when a regex string is found in it.
+    The line must collect to a table that matches the same of the collection.
+  Have ability to collect the time. Than time when 'You are no longer busy.' appears.
+  Has to export to a file.
+    
+
+]]--</script>
+					<eventHandlerList />
+				</ScriptGroup>
 			</ScriptGroup>
 			<ScriptGroup isActive="yes" isFolder="yes">
 				<name>data collection</name>
@@ -12012,12 +12039,6 @@ end --function sortCombatActions(stringToCheck)</script>
 end --function sortNonCombatActions</script>
 						<eventHandlerList />
 					</Script>
-				</ScriptGroup>
-				<ScriptGroup isActive="yes" isFolder="yes">
-					<name>CustomCollection</name>
-					<packageName></packageName>
-					<script></script>
-					<eventHandlerList />
 				</ScriptGroup>
 			</ScriptGroup>
 			<ScriptGroup isActive="yes" isFolder="yes">

--- a/src/TEC Client Triggers.xml
+++ b/src/TEC Client Triggers.xml
@@ -2143,7 +2143,7 @@ end --if getHelpDevs()</script>
 					<integer>0</integer>
 				</regexCodePropertyList>
 			</Trigger>
-			<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+			<Trigger isActive="no" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
 				<name>You are in the middle of something.</name>
 				<script>if parthiaMap.getEnabled() then --if player is using parthiaMap
   parthiaMap.directionWalked = false --direction the player has walked

--- a/src/TEC Client Triggers.xml
+++ b/src/TEC Client Triggers.xml
@@ -2143,7 +2143,7 @@ end --if getHelpDevs()</script>
 					<integer>0</integer>
 				</regexCodePropertyList>
 			</Trigger>
-			<Trigger isActive="no" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+			<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
 				<name>You are in the middle of something.</name>
 				<script>if parthiaMap.getEnabled() then --if player is using parthiaMap
   parthiaMap.directionWalked = false --direction the player has walked
@@ -2492,7 +2492,12 @@ end --if parthiaMap.getEnabled()</script>
 			<regexCodePropertyList />
 			<TriggerGroup isActive="no" isFolder="yes" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
 				<name>Courses 4 Part</name>
-				<script>if line:match([[&lt;/font&gt;&lt;font color=%"#%x+%"&gt;You are on a wide, grassy field. Little divots across the turf indicate that one or several horses have run across it at some point, perhaps in cavalry practice. The short grass is barely two inches high, and looks to be meticulously kept that way. Jutting from the ground is a brightly glowing lantern hanging from a pole. &lt;/font&gt;]]) then
+				<script>--[[
+Old style no color in room push
+&lt;/font&gt;You see a small yard enclosed within high, thick brick walls and without vegetation. The floor is completely covered in fine sand. The ceiling is open to the elements.  &lt;/font&gt;
+]]--
+
+if line:match([[&lt;/font&gt;.*You are on a wide, grassy field. Little divots across the turf indicate that one or several horses have run across it at some point, perhaps in cavalry practice. The short grass is barely two inches high, and looks to be meticulously kept that way. Jutting from the ground is a brightly glowing lantern hanging from a pole. &lt;/font&gt;]]) then
   if courses.lookRan then 
     tempTimer(.25, [[pecho("You begin to run the course.\nType stop to stop running courses.\n")]])
     tempTimer(1, [[send("go south")]])
@@ -2515,11 +2520,11 @@ elseif line:match("^You have a feeling this course has no more to offer you at t
 elseif line:match("^You must be standing.$") then
   deleteLine() --remove line from main console. line variable remains unchanged.
   tempTimer(1, [[send("stand")]])
-elseif line:match("&lt;/font&gt;&lt;font color=\"#%x+\"&gt;You are no longer busy%.&lt;/font&gt;&lt;/font&gt;") then
+elseif line:match("&lt;/font&gt;.*You are no longer busy%.&lt;/font&gt;&lt;/font&gt;") then
   tempTimer(1, [[send("go south")]])
 elseif line:match("^You arrive at a mud pit. ") then
   tempTimer(1, [[send("jump rope")]])
-elseif line:match([[   &lt;/font&gt;&lt;font color=%"#%x+%"&gt;You approach the start of a training course. This challenge is a muddy pit with a beam erected over it. Swinging from the beam is a muddy rope. It looks as though you have to jump at the rope to swing across the pit.  &lt;/font&gt;]]) then
+elseif line:match([[   &lt;/font&gt;.*You approach the start of a training course. This challenge is a muddy pit with a beam erected over it. Swinging from the beam is a muddy rope. It looks as though you have to jump at the rope to swing across the pit.  &lt;/font&gt;]]) then
   if courses.lookRan then
     tempTimer(.25, [[pecho("You begin to run the course.\nType stop to stop running courses.\n")]])
     tempTimer(1, [[send("jump rope")]])
@@ -2528,7 +2533,7 @@ elseif line:match([[   &lt;/font&gt;&lt;font color=%"#%x+%"&gt;You approach the 
   end
 elseif line:match([[^You arrive at a path through swinging weights. ]]) then
   tempTimer(1, [[send("go path")]])
-elseif line:match([[&lt;/font&gt;&lt;font color=%"#%x+%"&gt;This is the second test on this training course. Here you must test your agility by going along a path that has heavy bags of sand swinging across it. The object is to not get hit.  &lt;/font&gt;$]]) then
+elseif line:match([[&lt;/font&gt;.*This is the second test on this training course. Here you must test your agility by going along a path that has heavy bags of sand swinging across it. The object is to not get hit.  &lt;/font&gt;$]]) then
   if courses.lookRan then
     tempTimer(.25, [[pecho("You begin to run the course.\nType stop to stop running courses.\n")]])
     tempTimer(1, [[send("go path")]])
@@ -2537,7 +2542,7 @@ elseif line:match([[&lt;/font&gt;&lt;font color=%"#%x+%"&gt;This is the second t
   end --if courses.lookRan
 elseif line:match([[^You arrive at a circular track. ]]) then
   tempTimer(1, [[send("go track")]])
-elseif line:match([[&lt;/font&gt;&lt;font color=%"#%x+%"&gt;This third training area involves a circular track that has a pole spinning around it. You must go along the track, running laps and stay in front of the pole or it will knock you flat.  &lt;/font&gt;$]]) then
+elseif line:match([[&lt;/font&gt;.*This third training area involves a circular track that has a pole spinning around it. You must go along the track, running laps and stay in front of the pole or it will knock you flat.  &lt;/font&gt;$]]) then
   if courses.lookRan then
     tempTimer(.25, [[pecho("You begin to run the course.\nType stop to stop running courses.\n")]])
     tempTimer(1, [[send("go track")]])
@@ -2546,7 +2551,7 @@ elseif line:match([[&lt;/font&gt;&lt;font color=%"#%x+%"&gt;This third training 
   end --if courses.lookRan
 elseif line:match([[^You arrive at a bed of hot coals. ]]) then
   tempTimer(1, [[send("go coal")]])
-elseif line:match([[&lt;/font&gt;&lt;font color=%"#%x+%"&gt;This place is the last test on this course. You must prove your willpower by walking across the bed of hot coals.  &lt;/font&gt;$]]) then
+elseif line:match([[&lt;/font&gt;.*This place is the last test on this course. You must prove your willpower by walking across the bed of hot coals.  &lt;/font&gt;$]]) then
   if courses.lookRan then
     tempTimer(.25, [[pecho("You begin to run the course.\nType stop to stop running courses.\n")]])
     tempTimer(1, [[send("go coal")]])
@@ -2602,11 +2607,11 @@ elseif line:match("^You have a feeling this course has no more to offer you at t
 elseif line:match("^You must be standing.$") then
   deleteLine() --remove line from main console. line variable remains unchanged.
   tempTimer(1, [[send("stand")]])
-elseif line:match("&lt;/font&gt;&lt;font color=\"#%x+\"&gt;You are no longer busy%.&lt;/font&gt;&lt;/font&gt;") then
+elseif line:match("&lt;/font&gt;.*You are no longer busy%.&lt;/font&gt;&lt;/font&gt;") then
   tempTimer(1, [[send("go east")]])
 elseif line:match("^You arrive at a climbing wall. ") then
   tempTimer(1, [[send("climb rope")]])
-elseif line:match("&lt;/font&gt;&lt;font color=\"#%x+\"&gt;This is the first part of this training course. There is a tall wall here. The wall has a rope attached to it and the only way to proceed is to climb the rope.  &lt;/font&gt;$") then
+elseif line:match("&lt;/font&gt;.*This is the first part of this training course. There is a tall wall here. The wall has a rope attached to it and the only way to proceed is to climb the rope.  &lt;/font&gt;$") then
   if courses.lookRan or courses.notFourPart then
     tempTimer(.25, [[pecho("You begin to run the course.\nType stop to stop running courses.\n")]])
     tempTimer(1, [[send("climb rope")]])
@@ -2615,7 +2620,7 @@ elseif line:match("&lt;/font&gt;&lt;font color=\"#%x+\"&gt;This is the first par
   end --if courses.lookRan
 elseif line:match("^You arrive at a pool. ") then
   tempTimer(1, [[send("go plank")]])
-elseif line:match("&lt;/font&gt;&lt;font color=\"#%x+\"&gt;You are at the second part of this training course. There is a pool here with several planks across it. You must be perceptive and go across the one that doesn't swivel.  &lt;/font&gt;$") then
+elseif line:match("&lt;/font&gt;.*You are at the second part of this training course. There is a pool here with several planks across it. You must be perceptive and go across the one that doesn't swivel.  &lt;/font&gt;$") then
   if courses.lookRan or courses.notFourPart then 
     tempTimer(.25, [[pecho("You begin to run the course.\nType stop to stop running courses.\n")]])
     tempTimer(1, [[send("go plank")]])
@@ -2624,7 +2629,7 @@ elseif line:match("&lt;/font&gt;&lt;font color=\"#%x+\"&gt;You are at the second
   end --if courses.lookRan
 elseif line:match("^You arrive at a dropping pole. ") then
   tempTimer(1, [[send("go path")]])
-elseif line:match("&lt;/font&gt;&lt;font color=\"#%x+\"&gt;This is the last obstacle in this section of the training field. Before you is a path which goes underneath a rapidly descending beam. You need to run along the path and use your speed to get under the beam before it hits you.  &lt;/font&gt;$") then
+elseif line:match("&lt;/font&gt;.*This is the last obstacle in this section of the training field. Before you is a path which goes underneath a rapidly descending beam. You need to run along the path and use your speed to get under the beam before it hits you.  &lt;/font&gt;$") then
   if courses.lookRan or courses.notFourPart then
     tempTimer(.25, [[pecho("You begin to run the course.\nType stop to stop running courses.\n")]])
     tempTimer(1, [[send("go path")]])

--- a/src/TEC Client Triggers.xml
+++ b/src/TEC Client Triggers.xml
@@ -2148,7 +2148,17 @@ end --if getHelpDevs()</script>
 				<script>if parthiaMap.getEnabled() then --if player is using parthiaMap
   parthiaMap.directionWalked = false --direction the player has walked
   mapDebug("trigger You are in the middle of something., possible failed movement found set parthiaMap.directionWalked to false.")
-end --if parthiaMap.getEnabled()</script>
+end --if parthiaMap.getEnabled()
+
+-- If an interrupt is currently running and the interrupt has been set to repeat if it fails.
+-- Tell the system the last interrupt command failed.
+local groupName = parthiaAutomationInterruptRunning
+local groupPosition = parthiaAutomationInterruptGroupPosition
+local repeatInterruptOnFail = parthiaAutomationSaveTable[parthiaPlayer.CurrentCharacter.name].automationInterrupt[groupName][groupPosition].repeatOnFail
+if parthiaAutomationInterruptRunning and repeatInterruptOnFail then
+  -- Tell the interrupt system that the last command failed.
+  parthiaInterruptCommandSuccess = false
+end  -- if parthiaAutomationInterruptRunning</script>
 				<triggerType>0</triggerType>
 				<conditonLineDelta>0</conditonLineDelta>
 				<mStayOpen>0</mStayOpen>
@@ -2164,6 +2174,39 @@ end --if parthiaMap.getEnabled()</script>
 				</regexCodeList>
 				<regexCodePropertyList>
 					<integer>3</integer>
+				</regexCodePropertyList>
+			</Trigger>
+			<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+				<name>You will be busy for</name>
+				<script>if parthiaMap.getEnabled() then --if player is using parthiaMap
+  parthiaMap.directionWalked = false --direction the player has walked
+  mapDebug("trigger You are in the middle of something., possible failed movement found set parthiaMap.directionWalked to false.")
+end --if parthiaMap.getEnabled()
+
+-- If an interrupt is currently running and the interrupt has been set to repeat if it fails.
+-- Tell the system the last interrupt command failed.
+local groupName = parthiaAutomationInterruptRunning
+local groupPosition = parthiaAutomationInterruptGroupPosition
+local repeatInterruptOnFail = parthiaAutomationSaveTable[parthiaPlayer.CurrentCharacter.name].automationInterrupt[groupName][groupPosition].repeatOnFail
+if parthiaAutomationInterruptRunning and repeatInterruptOnFail then
+  -- Tell the interrupt system that the last command failed.
+  parthiaInterruptCommandSuccess = false
+end  -- if parthiaAutomationInterruptRunning</script>
+				<triggerType>0</triggerType>
+				<conditonLineDelta>0</conditonLineDelta>
+				<mStayOpen>0</mStayOpen>
+				<mCommand></mCommand>
+				<packageName></packageName>
+				<mFgColor>#ff0000</mFgColor>
+				<mBgColor>#ffff00</mBgColor>
+				<mSoundFile></mSoundFile>
+				<colorTriggerFgColor>#000000</colorTriggerFgColor>
+				<colorTriggerBgColor>#000000</colorTriggerBgColor>
+				<regexCodeList>
+					<string>You will be busy for</string>
+				</regexCodeList>
+				<regexCodePropertyList>
+					<integer>2</integer>
 				</regexCodePropertyList>
 			</Trigger>
 			<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">

--- a/src/TEC Client Triggers.xml
+++ b/src/TEC Client Triggers.xml
@@ -2149,18 +2149,7 @@ end --if getHelpDevs()</script>
   parthiaMap.directionWalked = false --direction the player has walked
   mapDebug("trigger You are in the middle of something., possible failed movement found set parthiaMap.directionWalked to false.")
 end --if parthiaMap.getEnabled()
-
--- If an interrupt is currently running and the interrupt has been set to repeat if it fails.
--- Tell the system the last interrupt command failed.
-if parthiaAutomationInterruptRunning then
-  local groupName = parthiaAutomationInterruptRunning
-  local groupPosition = parthiaAutomationInterruptGroupPosition
-  local repeatInterruptOnFail = parthiaAutomationSaveTable[parthiaPlayer.CurrentCharacter.name].automationInterrupt[groupName][groupPosition].repeatOnFail
-  if repeatInterruptOnFail then
-    -- Tell the interrupt system that the last command failed.
-    parthiaInterruptCommandSuccess = false
-  end -- repeatInterruptOnFail
-end  -- if parthiaAutomationInterruptRunning</script>
+</script>
 				<triggerType>0</triggerType>
 				<conditonLineDelta>0</conditonLineDelta>
 				<mStayOpen>0</mStayOpen>
@@ -2184,16 +2173,7 @@ end  -- if parthiaAutomationInterruptRunning</script>
   parthiaMap.directionWalked = false --direction the player has walked
   mapDebug("trigger You are in the middle of something., possible failed movement found set parthiaMap.directionWalked to false.")
 end --if parthiaMap.getEnabled()
-
--- If an interrupt is currently running and the interrupt has been set to repeat if it fails.
--- Tell the system the last interrupt command failed.
-local groupName = parthiaAutomationInterruptRunning
-local groupPosition = parthiaAutomationInterruptGroupPosition
-local repeatInterruptOnFail = parthiaAutomationSaveTable[parthiaPlayer.CurrentCharacter.name].automationInterrupt[groupName][groupPosition].repeatOnFail
-if parthiaAutomationInterruptRunning and repeatInterruptOnFail then
-  -- Tell the interrupt system that the last command failed.
-  parthiaInterruptCommandSuccess = false
-end  -- if parthiaAutomationInterruptRunning</script>
+</script>
 				<triggerType>0</triggerType>
 				<conditonLineDelta>0</conditonLineDelta>
 				<mStayOpen>0</mStayOpen>

--- a/src/TEC Client Triggers.xml
+++ b/src/TEC Client Triggers.xml
@@ -2152,12 +2152,14 @@ end --if parthiaMap.getEnabled()
 
 -- If an interrupt is currently running and the interrupt has been set to repeat if it fails.
 -- Tell the system the last interrupt command failed.
-local groupName = parthiaAutomationInterruptRunning
-local groupPosition = parthiaAutomationInterruptGroupPosition
-local repeatInterruptOnFail = parthiaAutomationSaveTable[parthiaPlayer.CurrentCharacter.name].automationInterrupt[groupName][groupPosition].repeatOnFail
-if parthiaAutomationInterruptRunning and repeatInterruptOnFail then
-  -- Tell the interrupt system that the last command failed.
-  parthiaInterruptCommandSuccess = false
+if parthiaAutomationInterruptRunning then
+  local groupName = parthiaAutomationInterruptRunning
+  local groupPosition = parthiaAutomationInterruptGroupPosition
+  local repeatInterruptOnFail = parthiaAutomationSaveTable[parthiaPlayer.CurrentCharacter.name].automationInterrupt[groupName][groupPosition].repeatOnFail
+  if repeatInterruptOnFail then
+    -- Tell the interrupt system that the last command failed.
+    parthiaInterruptCommandSuccess = false
+  end -- repeatInterruptOnFail
 end  -- if parthiaAutomationInterruptRunning</script>
 				<triggerType>0</triggerType>
 				<conditonLineDelta>0</conditonLineDelta>


### PR DESCRIPTION
  Minor bugfix: characters completing an interrupt would not automatically resume their last running automation.
  
  Minor bugfix: players running very old accounts that do not have the colored text patterns sent out for all standard room messages could not use the run courses command. This has been fixed.
  
  Bugfix: parthia automation and interrupt creation commands would not accept | in the input. Preventing the player from creating 'or' logic in their automations.
  
  Improvement: Made the choice to have the stop command stop all automation types that are currently running.
  
  Improvement: Dramatically shortened the help message that appears when a player clicks the 'create an automatio' and 'create an interrupt' windows.
      Previous to this there was too much text, so it was not being read.